### PR TITLE
Use `ensure_can_withdraw` instead of balance check

### DIFF
--- a/modules/synthetic-protocol/Cargo.toml
+++ b/modules/synthetic-protocol/Cargo.toml
@@ -21,11 +21,11 @@ orml-utilities = { path = "../../orml/utilities", default-features = false }
 module-primitives = { path = "../primitives", default-features = false }
 traits = { package = "module-traits", path = "../traits", default-features = false }
 synthetic-tokens = { package = "module-synthetic-tokens", path = "../synthetic-tokens", default-features = false }
+orml-tokens = { path = "../../orml/tokens", default-features = false }
+orml-currencies = { path = "../../orml/currencies", default-features = false }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-orml-tokens = { path = "../../orml/tokens", default-features = false }
-orml-currencies = { path = "../../orml/currencies", default-features = false }
 
 [features]
 default = ["std"]
@@ -40,6 +40,8 @@ std = [
 	"orml-prices/std",
 	"orml-traits/std",
 	"orml-utilities/std",
+	"orml-tokens/std",
+	"orml-currencies/std",
 	"module-primitives/std",
 	"traits/std",
 	"synthetic-tokens/std",

--- a/modules/synthetic-protocol/Cargo.toml
+++ b/modules/synthetic-protocol/Cargo.toml
@@ -21,11 +21,11 @@ orml-utilities = { path = "../../orml/utilities", default-features = false }
 module-primitives = { path = "../primitives", default-features = false }
 traits = { package = "module-traits", path = "../traits", default-features = false }
 synthetic-tokens = { package = "module-synthetic-tokens", path = "../synthetic-tokens", default-features = false }
-orml-tokens = { path = "../../orml/tokens", default-features = false }
-orml-currencies = { path = "../../orml/currencies", default-features = false }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate.git", default-features = false }
+orml-tokens = { path = "../../orml/tokens"}
+orml-currencies = { path = "../../orml/currencies"}
 
 [features]
 default = ["std"]
@@ -40,8 +40,6 @@ std = [
 	"orml-prices/std",
 	"orml-traits/std",
 	"orml-utilities/std",
-	"orml-tokens/std",
-	"orml-currencies/std",
 	"module-primitives/std",
 	"traits/std",
 	"synthetic-tokens/std",

--- a/modules/synthetic-protocol/src/lib.rs
+++ b/modules/synthetic-protocol/src/lib.rs
@@ -239,7 +239,8 @@ impl<T: Trait> Module<T> {
 		T::CollateralCurrency::ensure_can_withdraw(
 			&<SyntheticTokens<T>>::account_id(),
 			redeemed_collateral + pool_refund_collateral,
-		)?;
+		)
+		.map_err(|_| Error::<T>::NotEnoughLockedCollateralAvailable)?;
 
 		// TODO: calculate and add interest to `pool_refund_collateral`
 
@@ -329,10 +330,8 @@ impl<T: Trait> Module<T> {
 
 		// TODO: calculate and add interest to `pool_refund_collateral`
 
-		ensure!(
-			T::CollateralCurrency::balance(&<SyntheticTokens<T>>::account_id()) > pool_refund_collateral,
-			Error::<T>::NotEnoughLockedCollateralAvailable
-		);
+		T::CollateralCurrency::ensure_can_withdraw(&<SyntheticTokens<T>>::account_id(), pool_refund_collateral)
+			.map_err(|_| Error::<T>::NotEnoughLockedCollateralAvailable)?;
 
 		T::LiquidityPools::deposit_liquidity(&<SyntheticTokens<T>>::account_id(), pool_id, pool_refund_collateral)
 			.expect("ensured enough locked collateral; qed");

--- a/modules/synthetic-protocol/src/lib.rs
+++ b/modules/synthetic-protocol/src/lib.rs
@@ -329,7 +329,10 @@ impl<T: Trait> Module<T> {
 
 		// TODO: calculate and add interest to `pool_refund_collateral`
 
-		T::CollateralCurrency::ensure_can_withdraw(&<SyntheticTokens<T>>::account_id(), pool_refund_collateral)?;
+		ensure!(
+			T::CollateralCurrency::balance(&<SyntheticTokens<T>>::account_id()) > pool_refund_collateral,
+			Error::<T>::NotEnoughLockedCollateralAvailable
+		);
 
 		T::LiquidityPools::deposit_liquidity(&<SyntheticTokens<T>>::account_id(), pool_id, pool_refund_collateral)
 			.expect("ensured enough locked collateral; qed");

--- a/modules/synthetic-protocol/src/tests.rs
+++ b/modules/synthetic-protocol/src/tests.rs
@@ -810,7 +810,10 @@ fn withdraw_collateral_fails_if_not_enough_locked_collateral() {
 				collateral_position
 			));
 
-			assert_noop!(withdraw_collateral(ALICE), Error::<Runtime>::BalanceTooLow);
+			assert_noop!(
+				withdraw_collateral(ALICE),
+				Error::<Runtime>::NotEnoughLockedCollateralAvailable
+			);
 		});
 }
 

--- a/modules/synthetic-protocol/src/tests.rs
+++ b/modules/synthetic-protocol/src/tests.rs
@@ -326,7 +326,7 @@ fn redeem_fails_if_not_enough_locked_collateral() {
 
 			assert_noop!(
 				redeem_ausd(ALICE, SyntheticCurrency::balance(&ALICE)),
-				Error::<Runtime>::BalanceTooLow,
+				Error::<Runtime>::NotEnoughLockedCollateralAvailable,
 			);
 		});
 }
@@ -809,6 +809,8 @@ fn withdraw_collateral_fails_if_not_enough_locked_collateral() {
 				&SyntheticTokens::account_id(),
 				collateral_position
 			));
+
+			set_mock_feur_price(2, 1);
 
 			assert_noop!(
 				withdraw_collateral(ALICE),

--- a/modules/synthetic-protocol/src/tests.rs
+++ b/modules/synthetic-protocol/src/tests.rs
@@ -326,7 +326,7 @@ fn redeem_fails_if_not_enough_locked_collateral() {
 
 			assert_noop!(
 				redeem_ausd(ALICE, SyntheticCurrency::balance(&ALICE)),
-				Error::<Runtime>::NotEnoughLockedCollateralAvailable,
+				Error::<Runtime>::BalanceTooLow,
 			);
 		});
 }
@@ -810,10 +810,7 @@ fn withdraw_collateral_fails_if_not_enough_locked_collateral() {
 				collateral_position
 			));
 
-			assert_noop!(
-				withdraw_collateral(ALICE),
-				Error::<Runtime>::NotEnoughLockedCollateralAvailable
-			);
+			assert_noop!(withdraw_collateral(ALICE), Error::<Runtime>::BalanceTooLow);
 		});
 }
 


### PR DESCRIPTION
Fix issues #39.
Use `ensure_can_withdraw` instead of balance check in modules/synthetic-protocol/src/lib.rs