### PR TITLE
Update trader stop out process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,6 @@ dependencies = [
  "frame-support 2.0.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-system 2.0.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "orml-traits 0.0.1",
- "orml-utilities 0.0.1",
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-core 2.0.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -372,8 +372,8 @@ pub fn margin_trader_become_safe(who: &AccountId) -> DispatchResult {
 	ModuleMarginProtocol::trader_become_safe(<Runtime as system::Trait>::Origin::NONE, Address::from(who.clone()))
 }
 
-pub fn margin_trader_liquidate(who: &AccountId) -> DispatchResult {
-	ModuleMarginProtocol::trader_liquidate(<Runtime as system::Trait>::Origin::NONE, Address::from(who.clone()))
+pub fn margin_trader_stop_out(who: &AccountId) -> DispatchResult {
+	ModuleMarginProtocol::trader_stop_out(<Runtime as system::Trait>::Origin::NONE, Address::from(who.clone()))
 }
 
 pub fn margin_liquidity_pool_margin_call() -> DispatchResult {
@@ -384,6 +384,6 @@ pub fn margin_liquidity_pool_become_safe() -> DispatchResult {
 	ModuleMarginProtocol::liquidity_pool_become_safe(<Runtime as system::Trait>::Origin::NONE, LIQUIDITY_POOL_ID_0)
 }
 
-pub fn margin_liquidity_pool_liquidate() -> DispatchResult {
-	ModuleMarginProtocol::liquidity_pool_liquidate(<Runtime as system::Trait>::Origin::NONE, LIQUIDITY_POOL_ID_0)
+pub fn margin_liquidity_pool_force_close() -> DispatchResult {
+	ModuleMarginProtocol::liquidity_pool_force_close(<Runtime as system::Trait>::Origin::NONE, LIQUIDITY_POOL_ID_0)
 }

--- a/runtime/tests/margin_integration_test.rs
+++ b/runtime/tests/margin_integration_test.rs
@@ -241,7 +241,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_margin_trader_liquidate() {
+	fn test_margin_trader_stop_out() {
 		ExtBuilder::default()
 			.balances(vec![
 				(POOL::get(), AUSD, dollar(10_000)),
@@ -290,7 +290,7 @@ mod tests {
 				assert_ok!(set_oracle_price(vec![(FEUR, Price::from_rational(21, 10))]));
 				assert_ok!(margin_trader_margin_call(&ALICE::get()));
 				assert_noop!(
-					margin_trader_liquidate(&ALICE::get()),
+					margin_trader_stop_out(&ALICE::get()),
 					margin_protocol::Error::<Runtime>::NotReachedRiskThreshold
 				);
 
@@ -309,7 +309,7 @@ mod tests {
 				assert_ok!(margin_trader_become_safe(&ALICE::get()));
 
 				assert_ok!(set_oracle_price(vec![(FEUR, Price::from_rational(19, 10))]));
-				assert_ok!(margin_trader_liquidate(&ALICE::get()));
+				assert_ok!(margin_trader_stop_out(&ALICE::get()));
 
 				assert_eq!(collateral_balance(&ALICE::get()), dollar(4500));
 				assert_eq!(margin_balance(&ALICE::get()), Fixed128::from_natural(-245));
@@ -318,7 +318,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_margin_liquidity_pool_liquidate() {
+	fn test_margin_liquidity_pool_force_close() {
 		ExtBuilder::default()
 			.balances(vec![
 				(POOL::get(), AUSD, dollar(20_000)),
@@ -365,7 +365,7 @@ mod tests {
 				assert_ok!(set_oracle_price(vec![(FEUR, Price::from_rational(42, 10))]));
 				assert_ok!(margin_liquidity_pool_margin_call());
 				assert_noop!(
-					margin_liquidity_pool_liquidate(),
+					margin_liquidity_pool_force_close(),
 					margin_protocol::Error::<Runtime>::NotReachedRiskThreshold
 				);
 
@@ -386,7 +386,7 @@ mod tests {
 				assert_ok!(set_oracle_price(vec![(FEUR, Price::from_rational(50, 10))]));
 				assert_eq!(collateral_balance(&MockLaminarTreasury::account_id()), 0);
 				assert_eq!(margin_balance(&ALICE::get()), fixed_128_dollar(5000));
-				assert_ok!(margin_liquidity_pool_liquidate());
+				assert_ok!(margin_liquidity_pool_force_close());
 
 				// open_price = 3 * (1 + 0.01) = 3.03
 				// close_price = 5 * (1 - 0.01) = 4.95

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -321,7 +321,7 @@ mod steps {
 						.iter()
 						.map(|x| (parse_name(x.get(0)), parse_result(x.get(1))));
 					for (name, result) in iter {
-						result.assert(margin_trader_liquidate(&name));
+						result.assert(margin_trader_stop_out(&name));
 					}
 				})
 			})
@@ -337,7 +337,7 @@ mod steps {
 				world.execute_with(|| {
 					let iter = get_rows(step).iter().map(|x| parse_result(x.get(0)));
 					for result in iter {
-						result.assert(margin_liquidity_pool_liquidate());
+						result.assert(margin_liquidity_pool_force_close());
 					}
 				})
 			})


### PR DESCRIPTION
Closes #162 

Also renamed:
- `trader_liquidate` => `trader_stop_out`
- `liquidity_pool_liquidate` => `liquidity_pool_force_close`

to keep terms align with Laminar Margin Trading Paper and make them less ambiguous.